### PR TITLE
Set walk_dirs to false in permastruct, fix #14

### DIFF
--- a/include/post-type.php
+++ b/include/post-type.php
@@ -139,6 +139,9 @@ class PLL_TRS_Post_Type {
 			if ( false !== $args->rewrite && ( is_admin() || '' != get_option( 'permalink_structure' ) ) ) {
 				$permastruct_args = $args->rewrite;
 				$permastruct_args['feed'] = $permastruct_args['feeds'];
+				// Set the walk_dirs to false to avoid conflict with has_archive = false and the %language%
+				// in the rewrite directive. Without it the archive page redirect to the frontpage if has_archive is false.
+				$permastruct_args['walk_dirs'] = false;
 
 				// If "Hide URL language information for default language" option is
 				// set to true the rules has to be different for the default language.


### PR DESCRIPTION
This should fix a conflict when a page has the same slug has a content type and the content type has `has_archive => false`.

I've quickly tested it with different polylang and content type settings and it seems to work in all cases. Eventually some more tests would be nice before merging this.

See https://github.com/KLicheR/wp-polylang-translate-rewrite-slugs/issues/14 for more informations.
